### PR TITLE
bug-WDP190201-2

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -87,7 +87,7 @@ header {
         }
 
         .cart-counter {
-          width: 28px;
+          min-width: 28px;
           height: 27px;
           border-radius: 14px;
           background-color: $header-bg;
@@ -96,6 +96,7 @@ header {
           justify-content: center;
           font-size: 14px;
           color: rgb(224, 227, 237);
+          padding: 2px;
           position: absolute;
           top: 50%;
           right: 0;


### PR DESCRIPTION
Problem: Large numbers (over 3 digits) overflow shopping cart items counter. Counter should adjust width to current number (up to   5 digits).
There was fixed `width: 28px` for .cart-counter, I have replaced it with property `min-width` and additionaly set padding.