### PR TITLE
bug-WDP190201-7

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -201,6 +201,13 @@ header {
             color: transparent;
             text-shadow: 0 0 0 #000;
           }
+
+          &:hover {
+            cursor: pointer;
+            ~ i {
+              color: $primary;
+            }
+          }
         }
       }
 

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -195,6 +195,12 @@ header {
           font-size: 14px;
           position: relative;
           z-index: 1;
+
+          &:focus,
+          &:-moz-focusring {
+            color: transparent;
+            text-shadow: 0 0 0 #000;
+          }
         }
       }
 


### PR DESCRIPTION
On Firefox there is dotted 'outline' displayed around when select gets focus.
I have used trick to set color to transparent (to hide dotted lines) and set text-shadow, so text is still visible.